### PR TITLE
Enforce dark mode

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -44,7 +44,6 @@ import Header from "@/components/Header";
 import ActiveSectionContextProvider from "@/context/active-section-context";
 import ThemeContextProvider from "@/context/theme-context";
 import Footer from "@/components/Footer";
-import ThemeSwitch from "@/components/ThemeSwitch";
 
 
 const inter = Inter({ subsets: ["latin"] });
@@ -78,8 +77,7 @@ export default function RootLayout({
 					<ActiveSectionContextProvider>
 						<Header />
 						{children}
-						<Footer />
-						<ThemeSwitch />
+                                                <Footer />
 					</ActiveSectionContextProvider>
 				</ThemeContextProvider>
 			</body>

--- a/context/theme-context.tsx
+++ b/context/theme-context.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import React, { useEffect, useState, createContext, useContext } from "react";
+import React, { useEffect, createContext, useContext } from "react";
 
 type Theme = "light" | "dark";
 
@@ -16,42 +16,24 @@ type ThemeContextType = {
 const ThemeContext = createContext<ThemeContextType | null>(null);
 
 export default function ThemeContextProvider({
-	children,
+        children,
 }: ThemeContextProviderProps) {
-	const [theme, setTheme] = useState<Theme>("dark");
+        const theme: Theme = "dark";
 
-	// Function to apply the theme to the HTML tag
-	const applyTheme = (theme: Theme) => {
-		const root = document.documentElement;
-		if (theme === "dark") {
-			root.classList.add("dark");
-			root.classList.remove("light");
-		} else {
-			root.classList.add("light");
-			root.classList.remove("dark");
-		}
-	};
+        // Function to apply the theme to the HTML tag
+        const applyTheme = () => {
+                const root = document.documentElement;
+                root.classList.add("dark");
+                root.classList.remove("light");
+        };
 
-	const toggleTheme = () => {
-		const newTheme = theme === "light" ? "dark" : "light";
-		setTheme(newTheme);
-		window.localStorage.setItem("theme", newTheme);
-		applyTheme(newTheme);
-	};
+        const toggleTheme = () => {
+                // noop to keep dark mode enforced
+        };
 
-	useEffect(() => {
-		// Check localStorage for a saved theme
-		const localTheme = window.localStorage.getItem("theme") as Theme | null;
-
-		if (localTheme) {
-			setTheme(localTheme);
-			applyTheme(localTheme);
-		} else if (window.matchMedia("(prefers-color-scheme: dark)").matches) {
-			// Use system preference if no saved theme
-			setTheme("dark");
-			applyTheme("dark");
-		}
-	}, []);
+        useEffect(() => {
+                applyTheme();
+        }, []);
 
 	return (
 		<ThemeContext.Provider


### PR DESCRIPTION
## Summary
- enforce dark mode via ThemeContext
- remove theme switch from layout

## Testing
- `npm install`
- `npm run build` *(fails: Failed to fetch `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_6841c43860d48320a947a4f2de5cf4e9