### PR TITLE
Improve readability of experience and project sections

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -38,7 +38,7 @@ export default function RootLayout({
                                         }}
                                 />
                                 {/* Dark overlay for readability */}
-                                <div className="fixed inset-0 -z-20 bg-black/60" />
+                                <div className="fixed inset-0 -z-20 bg-black/80" />
 
                                 <ThemeContextProvider>
                                         <ActiveSectionContextProvider>

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -26,7 +26,7 @@ export default function Experience() {
                                 {experiencesData.map((item, index) => (
                                         <motion.div
                                                 key={index}
-                                                className="group relative flex flex-col bg-white/10 border border-white/20 backdrop-blur-md p-6 rounded-xl shadow-xl transition-transform hover:-translate-y-2"
+                                                className="group relative flex flex-col bg-white/20 border border-white/30 backdrop-blur-md p-6 rounded-xl shadow-xl transition-transform hover:-translate-y-2"
                                                 initial={{ opacity: 0, y: 50 }}
                                                 whileInView={{ opacity: 1, y: 0 }}
                                                 viewport={{ once: true }}
@@ -48,8 +48,8 @@ export default function Experience() {
 							<h4 className="text-md sm:text-lg font-medium text-gray-600 dark:text-gray-300 italic">
 								{item.title}
 							</h4>
-							<p className="text-sm text-gray-500">{item.location}</p>
-							<p className="text-sm text-gray-500">{item.date}</p>
+							<p className="text-sm text-gray-400">{item.location}</p>
+							<p className="text-sm text-gray-400">{item.date}</p>
 						</div>
 
                                                 <div className="mt-4 text-left text-gray-200 space-y-2">

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -31,7 +31,7 @@ export default function Projects() {
           <motion.div
             key={index}
             whileHover={{ scale: 1.05 }}
-            className="cursor-pointer bg-white/10 border border-white/20 backdrop-blur-md rounded-xl shadow-xl overflow-hidden group transition-transform hover:-translate-y-2"
+            className="cursor-pointer bg-white/20 border border-white/30 backdrop-blur-md rounded-xl shadow-xl overflow-hidden group transition-transform hover:-translate-y-2"
             onClick={() => setSelected(project)}
             initial={{ opacity: 0, y: 50 }}
             whileInView={{ opacity: 1, y: 0 }}
@@ -45,7 +45,7 @@ export default function Projects() {
             />
             <div className="p-4 text-left">
               <h3 className="text-lg font-semibold text-white mb-2">{project.title}</h3>
-              <p className="text-sm text-gray-300 mb-2 overflow-hidden max-h-16">{project.description}</p>
+              <p className="text-sm text-gray-200 mb-2 overflow-hidden max-h-16">{project.description}</p>
               <ul className="flex flex-wrap gap-2">
                 {project.tags.map((tag, idx) => (
                   <li key={idx} className="px-2 py-1 text-xs bg-white/20 rounded-full text-gray-200">
@@ -84,7 +84,7 @@ export default function Projects() {
               className="w-full h-48 object-cover rounded mb-4"
               quality={95}
             />
-            <p className="text-gray-300 mb-4 whitespace-pre-line">{selected.description}</p>
+            <p className="text-gray-200 mb-4 whitespace-pre-line">{selected.description}</p>
             <ul className="flex flex-wrap gap-2 mb-4">
               {selected.tags.map((tag, idx) => (
                 <li key={idx} className="px-2 py-1 text-xs bg-white/20 rounded-full text-gray-200">


### PR DESCRIPTION
## Summary
- darken background overlay for better readability
- lighten backgrounds for Experience and Projects cards
- lighten text colors to improve contrast

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_684270d0cd1c83208a59f1e46ba932b4