### PR TITLE
Improve button style and experience hover

### DIFF
--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -63,11 +63,11 @@ export default function Experience() {
                                                         </ul>
                                                 </div>
 
-						{/* Hover Effect */}
-						<div className="absolute inset-0 opacity-0 group-hover:opacity-100 bg-gradient-to-b from-transparent to-black/50 rounded-lg transition-opacity"></div>
-					</motion.div>
-				))}
-			</div>
+                                                {/* Hover Effect */}
+                                                <div className="absolute inset-0 rounded-lg bg-white/10 backdrop-blur-md opacity-0 group-hover:opacity-100 transition-all"></div>
+                                        </motion.div>
+                                ))}
+                        </div>
 		</motion.section>
 	);
 }

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -59,7 +59,7 @@ export default function Projects() {
       {projectsData.length > 5 && (
         <button
           onClick={() => setShowAll(!showAll)}
-          className="mt-4 text-sm text-blue-400 hover:underline"
+          className="mt-4 px-4 py-2 text-sm text-white bg-white/20 border border-white/30 backdrop-blur-md rounded-full shadow hover:bg-white/30 transition"
         >
           {showAll ? "Show Less" : "See More"}
         </button>


### PR DESCRIPTION
## Summary
- update "See More" button style to match translucent theme
- refine experience card hover with subtle light overlay

## Testing
- `npm run lint`

------
https://chatgpt.com/codex/tasks/task_e_6842bb4ea36c832096eacf0c434641b9