### PR TITLE
Improve social button layout

### DIFF
--- a/components/Contact.tsx
+++ b/components/Contact.tsx
@@ -42,7 +42,7 @@ export default function Contact() {
     <motion.section
       ref={ref}
       id="contact"
-      className="flex items-center justify-center h-screen text-center"
+      className="flex items-center justify-center min-h-screen text-center px-4"
       variants={containerVariants}
       initial="hidden"
       animate="visible"
@@ -52,7 +52,7 @@ export default function Contact() {
         {/* This div will wrap your content and ensure it doesn't stretch too wide */}
         <SectionHeading>Get in touch</SectionHeading>
         <p className="mb-8">Feel free to reach out to me!</p>
-        <div className="flex flex-col sm:flex-row justify-center gap-10">
+        <div className="flex flex-col sm:flex-row justify-center gap-6 sm:gap-10">
           <motion.a
             href="https://www.linkedin.com/in/jacoblim5/"
             target="_blank"

--- a/components/Experience.tsx
+++ b/components/Experience.tsx
@@ -15,18 +15,18 @@ export default function Experience() {
 	return (
 		<motion.section
 			ref={ref}
-			className="scroll-mt-[4.5rem] sm:scroll-mt-[6rem] mb-12 max-w-[90%] sm:max-w-[60rem] mx-auto text-center px-4 sm:px-8"
+                        className="scroll-mt-[4.5rem] sm:scroll-mt-[6rem] mb-12 max-w-[90%] sm:max-w-[70rem] mx-auto text-center px-4 sm:px-8"
 			initial={{ opacity: 0, y: 100 }}
 			animate={{ opacity: 1, y: 0 }}
 			transition={{ delay: 0.175 }}
 			id="experience"
 		>
 			<SectionHeading>My Experience</SectionHeading>
-			<div className="grid grid-cols-1 gap-8">
+                        <div className="grid grid-cols-1 sm:grid-cols-2 gap-8">
                                 {experiencesData.map((item, index) => (
                                         <motion.div
                                                 key={index}
-                                                className="group relative flex flex-col bg-white/20 border border-white/30 backdrop-blur-md p-6 rounded-xl shadow-xl transition-transform hover:-translate-y-2"
+                                                className="group relative flex flex-col bg-white/20 border border-white/30 backdrop-blur-md p-4 sm:p-6 rounded-xl shadow-xl transition-transform hover:-translate-y-2"
                                                 initial={{ opacity: 0, y: 50 }}
                                                 whileInView={{ opacity: 1, y: 0 }}
                                                 viewport={{ once: true }}
@@ -41,21 +41,21 @@ export default function Experience() {
                                                         </div>
                                                 </div>
 
-						<div className="text-left">
-                                                        <h3 className="text-xl font-bold text-gray-800 dark:text-white">
-								{item.company}
-							</h3>
-                                                        <h4 className="text-base sm:text-lg font-medium text-gray-600 dark:text-gray-300 italic">
-								{item.title}
-							</h4>
-							<p className="text-sm text-gray-400">{item.location}</p>
-							<p className="text-sm text-gray-400">{item.date}</p>
+                                                <div className="text-left">
+                                                        <h3 className="text-xl font-semibold text-white mb-1">
+                                                                {item.company}
+                                                        </h3>
+                                                        <h4 className="text-base text-gray-200 mb-1">
+                                                                {item.title}
+                                                        </h4>
+                                                        <p className="text-sm text-gray-300">{item.location}</p>
+                                                        <p className="text-sm text-gray-300">{item.date}</p>
 						</div>
 
                                                 <div className="mt-4 text-left text-gray-200 space-y-2">
                                                         <ul className="space-y-2">
                                                                 {item.description.split("\n").map((line, lineIndex) => (
-                                                                        <li key={lineIndex} className="flex items-start gap-2 text-sm">
+                                                                        <li key={lineIndex} className="flex items-start gap-2 text-sm text-gray-200">
                                                                                 <BsCheckCircle className="text-green-400 w-4 h-4 mt-[2px] flex-shrink-0" />
                                                                                 <span>{line}</span>
                                                                         </li>
@@ -63,11 +63,11 @@ export default function Experience() {
                                                         </ul>
                                                 </div>
 
-						{/* Hover Effect */}
-						<div className="absolute inset-0 opacity-0 group-hover:opacity-100 bg-gradient-to-b from-transparent to-black/50 rounded-lg transition-opacity"></div>
-					</motion.div>
-				))}
-			</div>
+                                                {/* Hover Effect */}
+                                                <div className="absolute inset-0 rounded-lg bg-white/10 backdrop-blur-md opacity-0 group-hover:opacity-100 transition-all"></div>
+                                        </motion.div>
+                                ))}
+                        </div>
 		</motion.section>
 	);
 }

--- a/components/Intro.tsx
+++ b/components/Intro.tsx
@@ -4,9 +4,8 @@ import Image from "next/image";
 import React from "react";
 import { motion } from "framer-motion";
 import Link from "next/link";
-import { BsArrowRight, BsLinkedin } from "react-icons/bs";
+import { BsArrowRight, BsLinkedin, BsGithub } from "react-icons/bs";
 import { HiDownload } from "react-icons/hi";
-import { FaGithubSquare } from "react-icons/fa";
 import { useSectionInView } from "@/lib/hooks";
 import { useActiveSectionContext } from "@/context/active-section-context";
 import { useState, useEffect } from "react";
@@ -81,45 +80,45 @@ export default function Intro() {
 				/>
 			</motion.h1>
 
-			<motion.div
-				className="flex flex-col sm:flex-row items-center justify-center gap-3 sm:gap-6 text-lg font-medium mb-6"
-				initial={{ opacity: 0, y: 100 }}
-				animate={{ opacity: 1, y: 0 }}
-				transition={{
-					delay: 0.1,
-				}}
-			>
-				<Link
-					href="#contact"
-                                        className="group bg-gray-900 text-white px-6 py-2 text-base sm:text-lg rounded-full outline-none focus:scale-110 hover:scale-110 hover:bg-gray-950 active:scale-105 transition"
-					onClick={() => {
-						setActiveSection("Contact");
-						setTimeOfLastClick(Date.now());
-					}}
-				>
-					Contact me here
-				</Link>
+                        <motion.div
+                                className="flex flex-row items-center justify-center gap-3 sm:gap-6 text-sm sm:text-lg font-medium mb-6"
+                                initial={{ opacity: 0, y: 100 }}
+                                animate={{ opacity: 1, y: 0 }}
+                                transition={{
+                                        delay: 0.1,
+                                }}
+                        >
+                                <Link
+                                        href="#contact"
+                                        className="group px-4 sm:px-6 py-2 text-sm sm:text-lg w-auto text-center bg-white/20 border border-white/30 backdrop-blur-md text-white rounded-full shadow outline-none focus:scale-110 hover:scale-110 hover:bg-white/30 active:scale-105 transition"
+                                        onClick={() => {
+                                                setActiveSection("Contact");
+                                                setTimeOfLastClick(Date.now());
+                                        }}
+                                >
+                                        Contact me here
+                                </Link>
 
-				<div className="flex items-center gap-4">
-					<a
-						className="bg-white p-3 text-gray-700 hover:text-gray-950 rounded-full transition focus:scale-[1.1] hover:scale-[1.1] active:scale-105 dark:bg-gray-800 dark:text-white dark:hover:text-gray-300"
-						href="https://www.linkedin.com/in/jacoblim5/"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<BsLinkedin size={24} />
-					</a>
+                                <div className="flex items-center gap-3 sm:gap-4">
+                                        <a
+                                                className="w-10 h-10 flex items-center justify-center bg-white/20 border border-white/30 backdrop-blur-md text-white rounded-full shadow transition focus:scale-110 hover:scale-110 hover:bg-white/30 active:scale-105"
+                                                href="https://www.linkedin.com/in/jacoblim5/"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                        >
+                                                <BsLinkedin className="w-6 h-6" />
+                                        </a>
 
-					<a
-						className="bg-white p-3 text-gray-700 hover:text-gray-950 rounded-full transition focus:scale-[1.1] hover:scale-[1.1] active:scale-105 dark:bg-gray-800 dark:text-white dark:hover:text-gray-300"
-						href="https://github.com/jacoblimjy"
-						target="_blank"
-						rel="noopener noreferrer"
-					>
-						<FaGithubSquare size={24} />
-					</a>
-				</div>
-			</motion.div>
+                                        <a
+                                                className="w-10 h-10 flex items-center justify-center bg-white/20 border border-white/30 backdrop-blur-md text-white rounded-full shadow transition focus:scale-110 hover:scale-110 hover:bg-white/30 active:scale-105"
+                                                href="https://github.com/jacoblimjy"
+                                                target="_blank"
+                                                rel="noopener noreferrer"
+                                        >
+                                                <BsGithub className="w-6 h-6" />
+                                        </a>
+                                </div>
+                        </motion.div>
 
 			{/* <motion.div
 				className="flex flex-col sm:flex-row items-center justify-center gap-2 px-4 text-lg font-medium"
@@ -159,12 +158,12 @@ export default function Intro() {
 
 				<a
 					className="bg-white p-4 text-gray-700 flex items-center gap-2 text-[1.35rem] rounded-full focus:scale-[1.15] hover:scale-[1.15] hover:text-gray-950 active:scale-105 transition cursor-pointer borderBlack dark:bg-white/10 dark:text-white/60"
-					href="https://github.com/jacoblimjy"
-					target="_blank"
-				>
-					<FaGithubSquare />
-				</a>
-			</motion.div> */}
-		</section>
-	);
+                                        href="https://github.com/jacoblimjy"
+                                        target="_blank"
+                                >
+                                        <BsGithub />
+                                </a>
+                        </motion.div> */}
+                </section>
+        );
 }

--- a/components/Projects.tsx
+++ b/components/Projects.tsx
@@ -29,7 +29,7 @@ export default function Projects() {
       id="projects"
     >
       <SectionHeading>My Projects</SectionHeading>
-      <div className="grid gap-6 mt-8 grid-cols-1">
+      <div className="grid gap-6 mt-8 grid-cols-1 sm:grid-cols-2">
         {displayedProjects.map((project, index) => (
           <motion.div
             key={index}
@@ -59,7 +59,7 @@ export default function Projects() {
       {projectsData.length > 5 && (
         <button
           onClick={() => setShowAll(!showAll)}
-          className="mt-4 text-sm text-blue-400 hover:underline"
+          className="mt-4 px-4 py-2 text-sm text-white bg-white/20 border border-white/30 backdrop-blur-md rounded-full shadow hover:bg-white/30 transition"
         >
           {showAll ? "Show Less" : "See More"}
         </button>

--- a/components/Skills.tsx
+++ b/components/Skills.tsx
@@ -34,7 +34,7 @@ export default function Skills() {
 			id="skills"
 		>
 			<SectionHeading>My Skills</SectionHeading>
-			<ul className="grid grid-cols-3 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-4 mt-8">
+                        <ul className="grid grid-cols-2 sm:grid-cols-4 md:grid-cols-6 lg:grid-cols-8 gap-4 mt-8">
 				{skillsData.map((skill, index) => (
 					<motion.li
 						className="flex items-center justify-center bg-gradient-to-tr from-gray-100 to-gray-200 dark:from-gray-800 dark:to-gray-700 rounded-lg shadow-md p-3 text-xs sm:text-sm font-medium text-gray-800 dark:text-white transform transition-transform hover:scale-105 hover:shadow-xl"


### PR DESCRIPTION
## Summary
- ensure contact and social buttons stay on one line
- darken the translucent styling for a classier look
- match GitHub icon style to LinkedIn so both are same size

## Testing
- `npm run lint` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_e_6842bb4ea36c832096eacf0c434641b9