### PR TITLE
Add animated starfield and hero tilt effect

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -4,6 +4,7 @@ import Header from "@/components/Header";
 import ActiveSectionContextProvider from "@/context/active-section-context";
 import ThemeContextProvider from "@/context/theme-context";
 import Footer from "@/components/Footer";
+import Starfield from "@/components/Starfield";
 
 // Use system fonts to avoid network fetch failures during build
 
@@ -30,16 +31,10 @@ export default function RootLayout({
                         <body
                                 className="relative text-gray-50 font-sans"
                         >
-                                {/* Background image */}
-                                <div
-                                        className="fixed inset-0 -z-30 bg-center bg-cover bg-no-repeat"
-                                        style={{
-                                                backgroundImage:
-                                                        "url('https://images.unsplash.com/photo-1506744038136-46273834b3fb?auto=format&fit=crop&w=2000&q=80')",
-                                        }}
-                                />
+                                {/* Animated starfield background */}
+                                <Starfield />
                                 {/* Dark overlay for readability */}
-                                <div className="fixed inset-0 -z-20 bg-black/80" />
+                                <div className="fixed inset-0 -z-30 bg-gradient-to-b from-black/60 via-black/80 to-black" />
 
                                 <ThemeContextProvider>
                                         <ActiveSectionContextProvider>

--- a/components/Intro.tsx
+++ b/components/Intro.tsx
@@ -11,6 +11,7 @@ import { useActiveSectionContext } from "@/context/active-section-context";
 import { useState, useEffect } from "react";
 // import meImg from "@/public/meImg.jpg";
 import ReactRotatingText from "react-rotating-text";
+import Tilt from "react-parallax-tilt";
 
 
 export default function Intro() {
@@ -61,11 +62,12 @@ export default function Intro() {
 				</div>
 			</div>
 
+                        <Tilt perspective={1000} glareEnable={true} glareMaxOpacity={0.2}>
                         <motion.h1
                                 className="text-3xl sm:text-4xl lg:text-5xl font-medium mb-6 px-4"
-				initial={{ opacity: 0, y: 100 }}
-				animate={{ opacity: 1, y: 0 }}
-			>
+                                initial={{ opacity: 0, y: 100 }}
+                                animate={{ opacity: 1, y: 0 }}
+                        >
 				<div className="text-center mb-2 sm:mb-4 lg:mb-6">
 					<span className="font-bold">Hello, I am Jacob!</span>
 				</div>
@@ -78,7 +80,8 @@ export default function Intro() {
 					emptyPause={1000}
 					cursor={true}
 				/>
-			</motion.h1>
+                        </motion.h1>
+                        </Tilt>
 
                         <motion.div
                                 className="flex flex-row items-center justify-center gap-2 sm:gap-6 text-lg font-medium mb-6"

--- a/components/Starfield.tsx
+++ b/components/Starfield.tsx
@@ -1,0 +1,61 @@
+"use client";
+
+import { useRef, useEffect } from "react";
+
+export default function Starfield() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext("2d");
+    if (!ctx) return;
+
+    let width = (canvas.width = window.innerWidth);
+    let height = (canvas.height = window.innerHeight);
+
+    const numStars = 200;
+    const stars = Array.from({ length: numStars }, () => ({
+      x: Math.random() * width,
+      y: Math.random() * height,
+      z: Math.random() * width,
+    }));
+
+    const render = () => {
+      if (!ctx) return;
+      ctx.fillStyle = "#000";
+      ctx.fillRect(0, 0, width, height);
+      for (const star of stars) {
+        star.z -= 1;
+        if (star.z <= 0) {
+          star.x = Math.random() * width;
+          star.y = Math.random() * height;
+          star.z = width;
+        }
+        const k = 128 / star.z;
+        const px = (star.x - width / 2) * k + width / 2;
+        const py = (star.y - height / 2) * k + height / 2;
+        if (px < 0 || px >= width || py < 0 || py >= height) continue;
+        const size = (1 - star.z / width) * 3;
+        ctx.fillStyle = "white";
+        ctx.fillRect(px, py, size, size);
+      }
+      animationFrameId = requestAnimationFrame(render);
+    };
+
+    let animationFrameId = requestAnimationFrame(render);
+
+    const handleResize = () => {
+      width = canvas.width = window.innerWidth;
+      height = canvas.height = window.innerHeight;
+    };
+    window.addEventListener("resize", handleResize);
+
+    return () => {
+      cancelAnimationFrame(animationFrameId);
+      window.removeEventListener("resize", handleResize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className="fixed inset-0 -z-40" />;
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,7 @@
         "react-dom": "18.2.0",
         "react-icons": "^5.0.1",
         "react-intersection-observer": "^9.5.3",
+        "react-parallax-tilt": "^1.7.296",
         "react-rotating-text": "^1.4.1",
         "react-vertical-timeline-component": "^3.6.0",
         "tailwindcss": "3.4.1",
@@ -3501,6 +3502,16 @@
       "version": "16.13.1",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
+    },
+    "node_modules/react-parallax-tilt": {
+      "version": "1.7.296",
+      "resolved": "https://registry.npmjs.org/react-parallax-tilt/-/react-parallax-tilt-1.7.296.tgz",
+      "integrity": "sha512-PYQ05RGIMAPKT5+8qXHjDcqA0b7htKDjEqYzjl28CP/0XYww60FwWbQpALjHng2PgjApHtSQ6AVcEk3g+EDt6Q==",
+      "license": "MIT",
+      "peerDependencies": {
+        "react": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0",
+        "react-dom": "^15.0.0 || ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0"
+      }
     },
     "node_modules/react-rotating-text": {
       "version": "1.4.1",

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
     "react-dom": "18.2.0",
     "react-icons": "^5.0.1",
     "react-intersection-observer": "^9.5.3",
+    "react-parallax-tilt": "^1.7.296",
     "react-rotating-text": "^1.4.1",
     "react-vertical-timeline-component": "^3.6.0",
     "tailwindcss": "3.4.1",


### PR DESCRIPTION
## Summary
- add new `Starfield` component for canvas-based star background
- integrate starfield into layout with gradient overlay
- wrap hero heading with `react-parallax-tilt`
- install `react-parallax-tilt`

## Testing
- `npm run lint`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68441f5c64b883208ac384331cc29629